### PR TITLE
fix: type assert panic

### DIFF
--- a/consumer/pull_consumer.go
+++ b/consumer/pull_consumer.go
@@ -144,7 +144,7 @@ func (c *defaultPullConsumer) getNextQueueOf(topic string) *primitive.MessageQue
 	v, exist := queueCounterTable.Load(topic)
 	if !exist {
 		index = -1
-		queueCounterTable.Store(topic, 0)
+		queueCounterTable.Store(topic, int64(0))
 	} else {
 		index = v.(int64)
 	}


### PR DESCRIPTION
The `sync.Map` store the value 0, its type is `int`, but in that code before fixed, the value `Load` by `sync.Map` is asserted as `int64`, so cause the type assert panic.
